### PR TITLE
Update README and implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Melpa](https://melpa.org/packages/gitignore-templates-badge.svg)](https://melpa.org/#/gitignore-templates)
 
-An Emacs package for creating .gitignore using GitHub or gitignore.io API
+An Emacs package for creating .gitignore using API supplied by
 
-- https://developer.github.com/v3/gitignore/
-- https://www.gitignore.io/
+- [GitHub](https://docs.github.com/en/rest/reference/gitignore)
+- [gitignore.io](https://docs.gitignore.io/use/api)
 
 ## Usage
 
@@ -17,7 +17,9 @@ Insert .gitignore template for NAME.
 
 Create a .gitignore file for NAME.
 
-## Customize
+## Customization
+
+`M-x customize-group RET gitignore-templates` lists all customizable variables. Using textual GUI customization interface is a recommended way to set user preferences. Any changes will be saved to `$HOME/.emacs`, which usually won't pollute your personal configuration. This is also less error-prone and can avoid possible typos.
 
 ### `gitignore-templates-api` (defaults to `gitignore.io`)
 
@@ -27,3 +29,22 @@ API used to get gitignore templates. Should be a symbol and one of
 ``` emacs-lisp
 (setq gitignore-templates-api 'github)
 ```
+
+## Proxy Setting
+
+If you're inside company's network, or facing with blocked or unstable connection to those APIs, a proxy setting is just for your need.
+
+Internally, gitignore-templates uses `url` package, which provides methods to enable proxy: `M-x customize-variable RET url-proxy-services`. It's a list of form `protocol url`. For example:
+
+```lisp
+(setq url-proxy-services '(("http" . "www.example.com:1234")
+                           ("https" . "www.example.com:1234")))
+```
+
+Incidentally, if you have your proxy related environment variables set up, Emacs can automatically read them.
+
+## Debug
+
+If you mistype an API or the template required is not found, a proper error message should be printed. But under some situations like the connection is blocked, there is possibility that you only get dump information.
+
+Customize variable `url-debug` using GUI interface. Set to `t`, which means print all. Then check them in buffer `*URL-DEBUG*` after invoking your problematic command.


### PR DESCRIPTION
Comment messages

- Internal functions now receive an optional argument indicating extra HTTP headers
- Modify cases of pcase

---

Hello there. I used this package several months ago. It was good as it worked.  
But at some point, the API could not fetch any data.  
I thought the API was changed making the package buggy.  
But without spare time and experience of elisp programming, I just leave it aside for a while.

Recently, I try to fix the problem mentioned before.  
However, after some efforts, I find that it's because the gitignore.io is blocked by cloudflare.
Actually, the access is still possible for some areas. But whatever, a proxy should solve this problem.

The primary modification is in README, like how to setup proxy.  
Basically, the implementation is correct and there is no need to change them.  
While, for the sake of learning elisp, I slightly modify some parts as shown in the diff.